### PR TITLE
fix: project images

### DIFF
--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -21,9 +21,9 @@ const projects = await getCollection('projects', ({ data }) => {
 					url={project.data.link}
 					title={project.data.title}
 					description={project.data.description}
-					alt={project.data.img_alt}
+					alt={project.data.image.alt}
 					tags={project.data.tags}
-					imageSrc={project.data.imageSrc}
+					src={project.data.image.url}
 				/>
 			))
 		}

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -2,14 +2,14 @@
 import projectImage from '@assets/images/quiz.png';
 import { Image } from '@astrojs/image/components';
 import Tags from '@components/ui/Tags.astro';
+
 interface Props {
-	url?: string;
-	alt?: string;
-	title?: string;
+	url: string;
+	alt: string;
 	description: string;
+	title: string;
 	tags: string[];
-	imageSrc: string;
-	children?: HTMLElement | HTMLElement[];
+	src: string;
 }
 
 const {
@@ -18,6 +18,7 @@ const {
 	description = 'Project Description',
 	title = 'Project title',
 	tags = ['Tags'],
+	src,
 } = Astro.props;
 ---
 
@@ -29,7 +30,7 @@ const {
 		<a href={url} aria-label="link to project">
 			<div class="relative flex items-end overflow-hidden rounded-xl">
 				<Image
-					src={projectImage}
+					src={src}
 					alt={alt}
 					aspectRatio="4:4"
 					format="png"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,7 +7,10 @@ const projectsCollection = defineCollection({
 		description: z.string(),
 		tags: z.array(z.string()),
 		link: z.string(),
-		img_alt: z.string().optional(),
+		image: z.object({
+			url: z.string(),
+			alt: z.string(),
+		})
 	}),
 });
 

--- a/src/content/projects/project-1.md
+++ b/src/content/projects/project-1.md
@@ -2,9 +2,9 @@
 inProgress: false
 title: Project ToDo
 description: Project description
-img_alt: project image alt text
 link: https://github.com/Veronika4Donchenko4/-31github
+image: 
+    url: '/src/assets/images/hotel.png'
+    alt: project image alt text
 tags: ['React', 'CSS', 'Typescript']
-
-
 ---

--- a/src/content/projects/project-2.md
+++ b/src/content/projects/project-2.md
@@ -2,7 +2,10 @@
 inProgress: false
 title: Project TicTacToe
 description: Project description
-img_alt: project image alt text
+image:
+    alt: project image alt text
+    url: '/src/assets/images/port.png'
+
 link: https://github.com/Veronika4Donchenko4/Tic-Tac-Toe
 tags: ['React', 'CSS', 'Typescript']
 ---

--- a/src/content/projects/project-3.md
+++ b/src/content/projects/project-3.md
@@ -2,7 +2,9 @@
 inProgress: false
 title: Project Expenses
 description: Project description
-img_alt: project image alt text
+image:
+    url: '/src/assets/images/hotel.png'
+    alt: project image alt text
 link: https://github.com/Veronika4Donchenko4/expenses
 tags: ['React', 'CSS', 'JS']
 ---

--- a/src/content/projects/project-4.md
+++ b/src/content/projects/project-4.md
@@ -2,7 +2,9 @@
 inProgress: false
 title: Project "Quote generation" 
 description: Project description
-img_alt: project image alt text
+image:
+    alt: project image alt text
+    url: '/src/assets/images/quiz.png'
 link: https://github.com/Veronika4Donchenko4/expenses
 tags: ['CSS', 'JS']
 ---

--- a/src/content/projects/project-5.md
+++ b/src/content/projects/project-5.md
@@ -1,8 +1,10 @@
 ---
-inProgress: true
+inProgress: false
 title: Project "hotel-customer" 
 description: Project description
-img_alt: project image alt text
+image:
+    alt: project image alt text
+    url: '/src/assets/images/hotel.png'
 link: https://github.com/Veronika4Donchenko4/hotel-customer
 tags: ['React', 'Redux', 'CSS', 'JS']
 ---

--- a/src/content/projects/project-6.md
+++ b/src/content/projects/project-6.md
@@ -1,8 +1,10 @@
 ---
-inProgress: true
+inProgress: false
 title: Project "Quiz" 
 description: Project description
-img_alt: project image alt text
+image:
+    alt: project image alt text
+    url: '/src/assets/images/project.png'
 link: https://github.com/Veronika4Donchenko4/quiz_website
 tags: ['React', 'Redux', 'CSS', 'JS']
 ---


### PR DESCRIPTION
This PR fixes the images that are fetched from the **projects** content collection. It does so by adding the following to the `/src/content/config.ts` file.

```js
image: z.object({
    url: z.string(),
    alt: z.string(),
})
```